### PR TITLE
feat: clean payload and send x-webhook-signature hash if secret set in ACP

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "eslint-plugin-import": "2.14.0"
   },
   "nbbpm": {
-    "compatibility": "^1.13.0"
+    "compatibility": "^1.15.0"
   }
 }

--- a/public/admin.js
+++ b/public/admin.js
@@ -21,29 +21,27 @@ define('admin/plugins/webhooks', ['settings'], function (settings) {
 					endpoint: $(this).find('.hook-endpoint').val(),
 				});
 			});
-			socket.emit('admin.plugins.webhooks.save', data, function (err) {
-				if (err) {
-					return app.alertError(err);
-				}
-				app.alertSuccess('Hooks Saved!');
-			});
-			saveSettings();
+
+			Promise.all([
+				new Promise((resolve, reject) => {
+					socket.emit('admin.plugins.webhooks.save', data, err => (!err ? resolve() : reject(err)));
+				}),
+				new Promise((resolve, reject) => {
+					settings.save('webhooks', $('.webhooks-settings'), err => (!err ? resolve() : reject(err)));
+				}),
+			]).then(() => {
+				app.alert({
+					type: 'success',
+					alert_id: 'webhooks-saved',
+					title: 'Settings Saved',
+				});
+			}).catch(app.alertError);
 		});
 
 		$('#hooks-parent').on('click', '.hook-remove', function () {
 			$(this).parent().parent().remove();
 		});
 	};
-
-	function saveSettings() {
-		settings.save('webhooks', $('.webhooks-settings'), function () {
-			app.alert({
-				type: 'success',
-				alert_id: 'webhooks-saved',
-				title: 'Settings Saved',
-			});
-		});
-	}
 
 	return WebHooks;
 });

--- a/public/admin.js
+++ b/public/admin.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-define('admin/plugins/webhooks', function () {
+define('admin/plugins/webhooks', ['settings'], function (settings) {
 	var WebHooks = {};
 
 	WebHooks.init = function () {
@@ -12,6 +12,7 @@ define('admin/plugins/webhooks', function () {
 			});
 		});
 
+		settings.load('webhooks', $('.webhooks-settings'));
 		$('#save').on('click', function () {
 			var data = [];
 			$('#hooks-parent tr').each(function () {
@@ -26,12 +27,23 @@ define('admin/plugins/webhooks', function () {
 				}
 				app.alertSuccess('Hooks Saved!');
 			});
+			saveSettings();
 		});
 
 		$('#hooks-parent').on('click', '.hook-remove', function () {
 			$(this).parent().parent().remove();
 		});
 	};
+
+	function saveSettings() {
+		settings.save('webhooks', $('.webhooks-settings'), function () {
+			app.alert({
+				type: 'success',
+				alert_id: 'webhooks-saved',
+				title: 'Settings Saved',
+			});
+		});
+	}
 
 	return WebHooks;
 });

--- a/public/templates/admin/plugins/webhooks.tpl
+++ b/public/templates/admin/plugins/webhooks.tpl
@@ -1,3 +1,18 @@
+<form role="form" class="webhooks-settings">
+	<div class="row">
+		<div class="col-sm-2 col-xs-12 settings-header">Security</div>
+		<div class="col-sm-10 col-xs-12">
+			<div class="form-group">
+				<label for="secret">Signature Verification Secret</label>
+				<input type="text" id="secret" name="secret" title="Signature Verification Secret" class="form-control" placeholder="mye3cr37p@55w0r[)">
+				<p class="help-block">
+					If set, then a header <code>x-webhook-signature</code> will be sent with the web hook. The value of this header is a `sha1` HMAC of the payload. To verify that the payload sender is authenticated, run the HMAC with this shared secret and ensure the hashes match.
+				</p>
+			</div>
+		</div>
+	</div>
+</form>
+
 <div class="row">
 	<div class="col-lg-12">
 		<h4>Webhooks</h4>
@@ -30,7 +45,10 @@
 		</div>
 		<div class="pull-right">
 			<button id="add-hook" class="btn btn-success"><i class="fa fa-plus"></i> Add Hook</button>
-			<button id="save" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
 		</div>
 	</div>
 </div>
+
+<button id="save" class="floating-button mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-button--colored">
+	<i class="material-icons">save</i>
+</button>


### PR DESCRIPTION
This PR introduces a `secret` ACP field which if set, calculates a SHA1 HMAC hash with the shared secret and sends it along in the `x-webhook-signature` header.

The receiving end needs to do the same to verify the payload authenticity.

**Breaking**: This changes the way the `POST` call is made. It is no longer a form request, but a JSON payload of type `application/json`.